### PR TITLE
Lein1 compatibility

### DIFF
--- a/lein-sleight/project.clj
+++ b/lein-sleight/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[leinjacker "0.3.0"]])
+  :dependencies [[leinjacker "0.4.0-SNAPSHOT"]])

--- a/lein-sleight/src/leiningen/sleight.clj
+++ b/lein-sleight/src/leiningen/sleight.clj
@@ -8,7 +8,7 @@
 
 (ns leiningen.sleight
   (:require [leinjacker.eval :as eval]
-            [leiningen.core.project :as project]))
+            [leinjacker.utils :as utils]))
 
 (defn arguments [args]
   (if (and (first args)
@@ -18,12 +18,7 @@
 
 (defn update-project-dependencies
   [project]
-  (let [profile-name (-> (gensym) name keyword)
-        added-profile (project/add-profiles project
-                                            {profile-name
-                                             {:dependencies [['sleight "0.2.0-SNAPSHOT"]]}})
-        merged-profile (project/merge-profiles added-profile [profile-name])]
-    merged-profile))
+  (utils/merge-projects project {:dependencies [['sleight "0.2.0-SNAPSHOT"]]}))
 
 (defn switch-form [transforms namespaces]
   `(sleight.core/switch-reader


### PR DESCRIPTION
I've changed the dependency merging yet again, so that once leinjacker's released with this new function, sleight will work on lein1 and lein2. I have it working on lein1 for my local build.
