### PR TITLE
Leinjacker has released a new stable version that makes sleight fully lein1 & lein2 compatible

### DIFF
--- a/lein-sleight/project.clj
+++ b/lein-sleight/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[leinjacker "0.4.0-SNAPSHOT"]])
+  :dependencies [[leinjacker "0.3.3"]]) 


### PR DESCRIPTION
Lgtm!

(and re-release to clojars so that I can continue to depend on sleight)
